### PR TITLE
chore: add config to others hosts access on local netwwork

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "devonly": "next dev",
-    "dev": "npm run services:up && npm run wait-for-postgres && npm run migration:up && next dev",
+    "dev": "npm run services:up && npm run wait-for-postgres && npm run migration:up && next dev -H 0.0.0.0",
     "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",
     "services:down": "docker compose -f infra/compose.yaml down",


### PR DESCRIPTION
Por padrão, o WSL (especialmente com WSL2) não permite acesso direto de fora da máquina. Você precisa criar um redirecionamento de porta do Windows para o WSL.

```bash
netsh interface portproxy add v4tov4 listenport=3000 listenaddress=0.0.0.0 connectport=3000 connectaddress=127.0.0.1
```

E permitir o tráfego no firewall:
```bash
netsh advfirewall firewall add rule name="NextJS 3000" dir=in action=allow protocol=TCP localport=3000
```